### PR TITLE
add dynamic distribution calculation and unit conversion for food items

### DIFF
--- a/src/controllers/cardapio_controller.py
+++ b/src/controllers/cardapio_controller.py
@@ -140,3 +140,47 @@ class CardapioController:
         }
 
         return g_p, g_c, round(g_v, 0), totais
+
+
+    @staticmethod
+    def calcular_distribuicao_dinamica():
+        """
+        Calcula as metas garantindo que Almoço/Jantar absorvam o saldo remanescente.
+        """
+        metas_globais = st.session_state.dieta["macros_alvo"]
+        # Percentuais reguláveis (exemplo vindo do state ou default)
+        dist = st.session_state.dieta.get("distribuicao_percentual", {"cafe": 0.2, "lanches": 0.15})
+        
+        # 1. Café da Manhã
+        meta_cafe = {k: v * dist["cafe"] for k, v in metas_globais.items() if isinstance(v, (int, float))}
+        
+        # 2. Lanches (considerando 2 lanches como exemplo)
+        meta_lanche = {k: v * dist["lanches"] for k, v in metas_globais.items() if isinstance(v, (int, float))}
+        
+        # 3. Almoço/Jantar (Ajuste Fino - Divide o que sobrou por 2)
+        sobra_fator = (1.0 - dist["cafe"] - (dist["lanches"] * 2)) / 2
+        meta_principal = {k: v * sobra_fator for k, v in metas_globais.items() if isinstance(v, (int, float))}
+        
+        return {
+            "Café da Manhã": meta_cafe,
+            "Lanche": meta_lanche,
+            "Almoço/Jantar": meta_principal
+        }
+        
+        
+    @staticmethod
+    def formatar_qtd(alimento_row, gramas):
+        """Converte gramas para unidades caseiras se disponível."""
+        unid = alimento_row.get("unidade_medida")
+        peso_un = alimento_row.get("peso_unidade")
+        
+        if unid and peso_un and peso_un > 0:
+            qtd_un = gramas / peso_un
+            qtd_label = int(qtd_un) if qtd_un % 1 == 0 else round(qtd_un, 1)
+            return f"{qtd_label} {unid}(s) ({gramas:.0f}g)"
+        return f"{gramas:.0f}g"
+        
+        
+       
+        
+        

--- a/src/controllers/cardapio_controller.py
+++ b/src/controllers/cardapio_controller.py
@@ -141,7 +141,6 @@ class CardapioController:
 
         return g_p, g_c, round(g_v, 0), totais
 
-
     @staticmethod
     def calcular_distribuicao_dinamica():
         """
@@ -149,38 +148,46 @@ class CardapioController:
         """
         metas_globais = st.session_state.dieta["macros_alvo"]
         # Percentuais reguláveis (exemplo vindo do state ou default)
-        dist = st.session_state.dieta.get("distribuicao_percentual", {"cafe": 0.2, "lanches": 0.15})
-        
+        dist = st.session_state.dieta.get(
+            "distribuicao_percentual", {"cafe": 0.2, "lanches": 0.15}
+        )
+
         # 1. Café da Manhã
-        meta_cafe = {k: v * dist["cafe"] for k, v in metas_globais.items() if isinstance(v, (int, float))}
-        
+        meta_cafe = {
+            k: v * dist["cafe"]
+            for k, v in metas_globais.items()
+            if isinstance(v, (int, float))
+        }
+
         # 2. Lanches (considerando 2 lanches como exemplo)
-        meta_lanche = {k: v * dist["lanches"] for k, v in metas_globais.items() if isinstance(v, (int, float))}
-        
+        meta_lanche = {
+            k: v * dist["lanches"]
+            for k, v in metas_globais.items()
+            if isinstance(v, (int, float))
+        }
+
         # 3. Almoço/Jantar (Ajuste Fino - Divide o que sobrou por 2)
         sobra_fator = (1.0 - dist["cafe"] - (dist["lanches"] * 2)) / 2
-        meta_principal = {k: v * sobra_fator for k, v in metas_globais.items() if isinstance(v, (int, float))}
-        
+        meta_principal = {
+            k: v * sobra_fator
+            for k, v in metas_globais.items()
+            if isinstance(v, (int, float))
+        }
+
         return {
             "Café da Manhã": meta_cafe,
             "Lanche": meta_lanche,
-            "Almoço/Jantar": meta_principal
+            "Almoço/Jantar": meta_principal,
         }
-        
-        
+
     @staticmethod
     def formatar_qtd(alimento_row, gramas):
         """Converte gramas para unidades caseiras se disponível."""
         unid = alimento_row.get("unidade_medida")
         peso_un = alimento_row.get("peso_unidade")
-        
+
         if unid and peso_un and peso_un > 0:
             qtd_un = gramas / peso_un
             qtd_label = int(qtd_un) if qtd_un % 1 == 0 else round(qtd_un, 1)
             return f"{qtd_label} {unid}(s) ({gramas:.0f}g)"
         return f"{gramas:.0f}g"
-        
-        
-       
-        
-        

--- a/src/services/data_service.py
+++ b/src/services/data_service.py
@@ -90,11 +90,20 @@ def carregar_custom_foods():
             if col not in df.columns:
                 df[col] = None if col == "unidade_medida" else 0.0
         return df
-    
+
     return pd.DataFrame(
         columns=[
-            "alimento", "kcal", "prot", "gord", "carb", "fibra", 
-            "colesterol", "sodio", "ferro", "unidade_medida", "peso_unidade"
+            "alimento",
+            "kcal",
+            "prot",
+            "gord",
+            "carb",
+            "fibra",
+            "colesterol",
+            "sodio",
+            "ferro",
+            "unidade_medida",
+            "peso_unidade",
         ]
     )
 

--- a/src/services/data_service.py
+++ b/src/services/data_service.py
@@ -85,19 +85,16 @@ def carregar_dados() -> pd.DataFrame | None:
 
 def carregar_custom_foods():
     if os.path.exists(PATH_CUSTOM):
-        return pd.read_csv(PATH_CUSTOM)
-    # Se não existir, retorna um DataFrame vazio com as colunas corretas
+        df = pd.read_csv(PATH_CUSTOM)
+        for col in ["unidade_medida", "peso_unidade"]:
+            if col not in df.columns:
+                df[col] = None if col == "unidade_medida" else 0.0
+        return df
+    
     return pd.DataFrame(
         columns=[
-            "alimento",
-            "kcal",
-            "prot",
-            "gord",
-            "carb",
-            "fibra",
-            "colesterol",
-            "sodio",
-            "ferro",
+            "alimento", "kcal", "prot", "gord", "carb", "fibra", 
+            "colesterol", "sodio", "ferro", "unidade_medida", "peso_unidade"
         ]
     )
 

--- a/src/views/biblioteca_view.py
+++ b/src/views/biblioteca_view.py
@@ -92,11 +92,13 @@ def render_biblioteca(df_taco):
                 value=100.0,
                 help="Qual o peso que os macros abaixo representam?",
             )
-            
+
             st.write("---")
             st.caption("📏 Unidade Caseira (Ex: 1 Fatia de pão = 25g)")
             col_u1, col_u2 = st.columns(2)
-            u_nome = col_u1.text_input("Nome da Unidade", placeholder="Fatia, Ovo, Pote...")
+            u_nome = col_u1.text_input(
+                "Nome da Unidade", placeholder="Fatia, Ovo, Pote..."
+            )
             u_peso = col_u2.number_input("Peso de 1 unidade (g)", min_value=0.0)
 
             st.write("---")
@@ -130,7 +132,7 @@ def render_biblioteca(df_taco):
                             "sodio": sod_raw * fator,
                             "ferro": ferro_raw * fator,
                             "unidade_medida": u_nome if u_nome else None,
-                            "peso_unidade": u_peso if u_peso > 0 else 0.0
+                            "peso_unidade": u_peso if u_peso > 0 else 0.0,
                         }
                     ]
                 )

--- a/src/views/biblioteca_view.py
+++ b/src/views/biblioteca_view.py
@@ -92,6 +92,12 @@ def render_biblioteca(df_taco):
                 value=100.0,
                 help="Qual o peso que os macros abaixo representam?",
             )
+            
+            st.write("---")
+            st.caption("📏 Unidade Caseira (Ex: 1 Fatia de pão = 25g)")
+            col_u1, col_u2 = st.columns(2)
+            u_nome = col_u1.text_input("Nome da Unidade", placeholder="Fatia, Ovo, Pote...")
+            u_peso = col_u2.number_input("Peso de 1 unidade (g)", min_value=0.0)
 
             st.write("---")
             st.caption("Insira os macros conforme aparecem no rótulo:")
@@ -123,6 +129,8 @@ def render_biblioteca(df_taco):
                             "colesterol": col_raw * fator,
                             "sodio": sod_raw * fator,
                             "ferro": ferro_raw * fator,
+                            "unidade_medida": u_nome if u_nome else None,
+                            "peso_unidade": u_peso if u_peso > 0 else 0.0
                         }
                     ]
                 )


### PR DESCRIPTION
This pull request introduces enhancements to the handling and display of food units and their weights, as well as improvements to the calculation of dietary macro distributions. The main focus is on supporting "unidade caseira" (household units) for food items and ensuring these are integrated throughout the data pipeline—from input, through storage, to display and calculation.

**Support for household units and macro distribution:**

*Data model and persistence:*
- Added `unidade_medida` (unit name) and `peso_unidade` (unit weight) columns to the custom foods DataFrame, ensuring these fields are present when loading and creating new custom food entries.

*User interface for food entry:*
- Updated the food library view to allow users to input a household unit name and its corresponding weight in grams when adding new foods. These values are now saved alongside the food's nutritional information. [[1]](diffhunk://#diff-33c9d6b8305fe08082ca33410dbe3b9022992b279e402ab7736a81a8c151aefcR96-R101) [[2]](diffhunk://#diff-33c9d6b8305fe08082ca33410dbe3b9022992b279e402ab7736a81a8c151aefcR132-R133)

*Controller utilities and calculation logic:*
- Introduced a `formatar_qtd` static method to the controller that formats quantities in grams into household units when available, improving display clarity for end-users.
- Added a `calcular_distribuicao_dinamica` static method to calculate macro distributions dynamically, ensuring lunch and dinner absorb any remaining targets after breakfast and snacks are accounted for.